### PR TITLE
feat: oauth2 실패 핸들러 추가

### DIFF
--- a/motimo-api/src/main/java/kr/co/api/config/SecurityConfig.java
+++ b/motimo-api/src/main/java/kr/co/api/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import kr.co.api.security.CustomUserDetailsService;
 import kr.co.api.security.jwt.TokenAuthenticationFilter;
 import kr.co.api.security.jwt.TokenProvider;
 import kr.co.api.security.oauth2.CustomOAuth2UserService;
+import kr.co.api.security.oauth2.OAuth2AuthenticationFailureHandler;
 import kr.co.api.security.oauth2.OAuth2AuthenticationSuccessHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -29,6 +30,7 @@ public class SecurityConfig {
     private final CustomUserDetailsService customUserDetailsService;
     private final CustomOAuth2UserService customOAuth2UserService;
     private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
+    private final OAuth2AuthenticationFailureHandler oAuth2AuthenticationFailureHandler;
 
     @Bean
     public TokenAuthenticationFilter tokenAuthenticationFilter() {
@@ -55,7 +57,8 @@ public class SecurityConfig {
                 )
                 .userDetailsService(customUserDetailsService)
                 .exceptionHandling(exceptionHandler ->
-                        exceptionHandler.authenticationEntryPoint(new CustomAuthenticationEntryPoint())
+                        exceptionHandler.authenticationEntryPoint(
+                                new CustomAuthenticationEntryPoint())
                 )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
@@ -78,6 +81,7 @@ public class SecurityConfig {
                                 .userService(customOAuth2UserService)
                         )
                         .successHandler(oAuth2AuthenticationSuccessHandler)
+                        .failureHandler(oAuth2AuthenticationFailureHandler)
                 );
 
         http.addFilterBefore(tokenAuthenticationFilter(),

--- a/motimo-api/src/main/java/kr/co/api/security/oauth2/OAuth2AuthenticationFailureHandler.java
+++ b/motimo-api/src/main/java/kr/co/api/security/oauth2/OAuth2AuthenticationFailureHandler.java
@@ -1,0 +1,31 @@
+package kr.co.api.security.oauth2;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class OAuth2AuthenticationFailureHandler implements AuthenticationFailureHandler {
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+            AuthenticationException exception) throws IOException {
+        log.error("OAuth2 인증 실패: {}", exception.getMessage());
+
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json;charset=UTF-8");
+
+        String json = new ObjectMapper().writeValueAsString(
+                Map.of("error", "OAuth2 인증 실패", "message", exception.getLocalizedMessage())
+        );
+
+        response.getWriter().write(json);
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
#31 [feat] OAuth2 인증 실패 처리 핸들러 추가

resolved: #31 

## ✨ 작업 개요
oauth2 인증 실패했을때의 핸들러 추가했어요~!


## ✅ 작업 상세 내용

## 📸 스크린샷 (선택)

## 💬 기타 참고 사항

## 🔍 고민 지점
