### PR TITLE
[Feat] 투두 수정 API 

### DIFF
--- a/motimo-api/src/main/java/kr/co/api/todo/TodoController.java
+++ b/motimo-api/src/main/java/kr/co/api/todo/TodoController.java
@@ -5,6 +5,7 @@ import kr.co.api.security.annotation.AuthUser;
 import kr.co.api.todo.docs.TodoControllerSwagger;
 import kr.co.api.todo.rqrs.TodoResultRq;
 import kr.co.api.todo.rqrs.TodoResultRs;
+import kr.co.api.todo.rqrs.TodoUpdateRq;
 import kr.co.api.todo.service.TodoCommandService;
 import kr.co.api.todo.service.TodoQueryService;
 import org.springframework.http.HttpStatus;
@@ -15,6 +16,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -57,6 +60,13 @@ public class TodoController implements TodoControllerSwagger {
         todoCommandService.toggleTodoCompletion(userId, todoId);
     }
 
+    @PutMapping("/{todoId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void updateTodo(@AuthUser UUID userId, @PathVariable UUID todoId,
+            @RequestBody TodoUpdateRq request) {
+        todoCommandService.updateTodo(userId, todoId, request.title(), request.date());
+    }
+
     @DeleteMapping("/{todoId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deleteById(@AuthUser UUID userId, @PathVariable UUID todoId) {
@@ -64,6 +74,5 @@ public class TodoController implements TodoControllerSwagger {
     }
 
     // todo: 투두 결과 수정 기능 추가
-    // todo: 투두 내용 수정 기능 추가
     // todo: 투두 삭제 기능 추가
 }

--- a/motimo-api/src/main/java/kr/co/api/todo/docs/TodoControllerSwagger.java
+++ b/motimo-api/src/main/java/kr/co/api/todo/docs/TodoControllerSwagger.java
@@ -10,8 +10,10 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.UUID;
 import kr.co.api.todo.rqrs.TodoResultRq;
 import kr.co.api.todo.rqrs.TodoResultRs;
+import kr.co.api.todo.rqrs.TodoUpdateRq;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -48,12 +50,27 @@ public interface TodoControllerSwagger {
     @ApiResponses({
             @ApiResponse(responseCode = "204", description = "TODO 완료 상태 변경 성공"),
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @ApiResponse(responseCode = "403", description = "투두 수정에 대한 권한이 없는 사용자"),
             @ApiResponse(responseCode = "404", description = "TODO를 찾을 수 없음")
     })
     void toggleTodoCompletion(
             UUID userId,
             @Parameter(description = "TODO ID", required = true, example = "123e4567-e89b-12d3-a456-426614174000")
             @PathVariable UUID todoId
+    );
+
+    @Operation(summary = "투두 업데이트", description = "투두 내용을 수정합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "투두 내용 수정 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @ApiResponse(responseCode = "403", description = "투두 수정에 대한 권한이 없는 사용자"),
+            @ApiResponse(responseCode = "404", description = "투두를 찾을 수 없음")
+    })
+    void updateTodo(
+            UUID userId,
+            @Parameter(description = "TODO ID", required = true, example = "123e4567-e89b-12d3-a456-426614174000")
+            @PathVariable UUID todoId,
+            @RequestBody @Schema(implementation = TodoUpdateRq.class) TodoUpdateRq request
     );
 
     @Operation(summary = "투두 삭제", description = "특정 투두를 삭제합니다.")

--- a/motimo-api/src/main/java/kr/co/api/todo/rqrs/TodoUpdateRq.java
+++ b/motimo-api/src/main/java/kr/co/api/todo/rqrs/TodoUpdateRq.java
@@ -1,0 +1,12 @@
+package kr.co.api.todo.rqrs;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+
+public record TodoUpdateRq(
+        @Schema(description = "새로운 투두 타이틀", example = "영단어 외우기")
+        String title,
+        @Schema(description = "새로운 투두 완료 날짜", format = "date")
+        LocalDate date) {
+
+}

--- a/motimo-api/src/main/java/kr/co/api/todo/service/TodoCommandService.java
+++ b/motimo-api/src/main/java/kr/co/api/todo/service/TodoCommandService.java
@@ -64,6 +64,13 @@ public class TodoCommandService {
         todoRepository.save(todo);
     }
 
+    public void updateTodo(UUID userId, UUID todoId, String title, LocalDate date) {
+        Todo todo = todoRepository.findById(todoId);
+        todo.validateAuthor(userId);
+        todo.update(title, date);
+        todoRepository.save(todo);
+    }
+
     public void deleteById(UUID userId, UUID todoId) {
         Todo todo = todoRepository.findById(todoId);
         todo.validateAuthor(userId);


### PR DESCRIPTION
## 📌 관련 이슈
#32 
resolved: #32 

<br>

## ✨ 작업 개요
투두 수정 API 추가했습니다.

<br>

## ✅ 작업 상세 내용
- [x] Todo 수정 API
- [x] Todo 수정 비즈니스 로직 
- [x] 테스트 코드 작성

<br>

## 📸 스크린샷 (선택)

<br>

## 💬 기타 참고 사항

🤔  궁금한점!! 
종은님 코드를 보면 생성시에 Id를 `String`으로 변환하여 응답으로 보내주고 있는데!! 
수정 / 삭제하는 경우에는 Id 값을 응답으로 보내주지 않는걸까요!?
또, String으로 Id 값을 보내주도록 한다면 클라이언트에서 요청시에 `PathVariable`로 들어오는 Id의 타입도 `String` 이어야 할 것 같은데 그런 방향으로 수정하면 될까요~?

[요약?]
1. 응답 일관성
- 생성: ID 반환?!? ✅
- 수정: ID 반환 없음?!?! ❓ 
- 삭제: void 반환?!? ✅
  
  
2. `@PathVariable String goalId` + 내부에서 UUID 변환 ?!?


<br>

## 🔍 고민 지점
