### PR TITLE
[그룹] 그룹 조회 API

### DIFF
--- a/motimo-api/src/main/java/kr/co/api/group/GroupController.java
+++ b/motimo-api/src/main/java/kr/co/api/group/GroupController.java
@@ -1,6 +1,5 @@
 package kr.co.api.group;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 import kr.co.api.group.docs.GroupControllerSwagger;
@@ -85,11 +84,8 @@ public class GroupController implements GroupControllerSwagger {
 
     @GetMapping("/{groupId}/members")
     public List<GroupMemberRs> getGroupMembers(@AuthUser UUID userId, @PathVariable UUID groupId) {
-        return List.of(
-                new GroupMemberRs(UUID.randomUUID(), "닉네임1", LocalDateTime.now(), true),
-                new GroupMemberRs(UUID.randomUUID(), "닉네임1", LocalDateTime.now(), false),
-                new GroupMemberRs(userId, "본인입니다", LocalDateTime.now(), false)
-        );
+        return groupQueryService.getGroupMemberList(userId, groupId).stream()
+                .map(GroupMemberRs::from).toList();
     }
 
     @DeleteMapping("/{groupId}/members/me")

--- a/motimo-api/src/main/java/kr/co/api/group/GroupController.java
+++ b/motimo-api/src/main/java/kr/co/api/group/GroupController.java
@@ -13,6 +13,7 @@ import kr.co.api.group.rqrs.message.GroupChatRs;
 import kr.co.api.group.rqrs.message.NewMessageRs;
 import kr.co.api.group.service.GroupCommandService;
 import kr.co.api.group.service.GroupMessageQueryService;
+import kr.co.api.group.service.GroupQueryService;
 import kr.co.api.security.annotation.AuthUser;
 import kr.co.domain.common.pagination.PagingDirection;
 import kr.co.domain.group.reaction.ReactionType;
@@ -34,20 +35,21 @@ public class GroupController implements GroupControllerSwagger {
 
     private final GroupMessageQueryService groupMessageQueryService;
     private final GroupCommandService groupCommandService;
+    private final GroupQueryService groupQueryService;
 
     public GroupController(final GroupMessageQueryService groupMessageQueryService,
-            final GroupCommandService groupCommandService) {
+            final GroupCommandService groupCommandService,
+            final GroupQueryService groupQueryService) {
         this.groupMessageQueryService = groupMessageQueryService;
         this.groupCommandService = groupCommandService;
+        this.groupQueryService = groupQueryService;
     }
 
     @GetMapping("/me")
-    public List<JoinedGroupRs> getJoinedGroup(@AuthUser UUID userId) {
-
-        return List.of(
-                new JoinedGroupRs("백다방 백잔 먹기", LocalDateTime.now(), false),
-                new JoinedGroupRs("충전기 만들기", LocalDateTime.now(), true)
-        );
+    public List<JoinedGroupRs> getJoinedGroups(@AuthUser UUID userId) {
+        return groupQueryService.getJoinedGroupList(userId).stream().map(
+                JoinedGroupRs::from
+        ).toList();
     }
 
     @PostMapping("/random-join")
@@ -97,7 +99,8 @@ public class GroupController implements GroupControllerSwagger {
 
     @PostMapping("/{groupId}/members/{targetUserId}/poke")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void sendPokeNotification(@AuthUser UUID userId, @PathVariable UUID groupId, @PathVariable UUID targetUserId) {
+    public void sendPokeNotification(@AuthUser UUID userId, @PathVariable UUID groupId,
+            @PathVariable UUID targetUserId) {
         groupCommandService.createPokeNotification(userId, groupId, targetUserId);
     }
 }

--- a/motimo-api/src/main/java/kr/co/api/group/GroupController.java
+++ b/motimo-api/src/main/java/kr/co/api/group/GroupController.java
@@ -3,6 +3,7 @@ package kr.co.api.group;
 import java.util.List;
 import java.util.UUID;
 import kr.co.api.group.docs.GroupControllerSwagger;
+import kr.co.api.group.rqrs.GroupDetailRs;
 import kr.co.api.group.rqrs.GroupIdRs;
 import kr.co.api.group.rqrs.GroupJoinRq;
 import kr.co.api.group.rqrs.GroupMemberRs;
@@ -49,6 +50,11 @@ public class GroupController implements GroupControllerSwagger {
         return groupQueryService.getJoinedGroupList(userId).stream().map(
                 JoinedGroupRs::from
         ).toList();
+    }
+
+    @GetMapping("/{groupId}")
+    public GroupDetailRs getGroupDetail(@AuthUser UUID userId, @PathVariable UUID groupId) {
+        return GroupDetailRs.from(groupQueryService.getGroupDetail(userId, groupId));
     }
 
     @PostMapping("/random-join")

--- a/motimo-api/src/main/java/kr/co/api/group/docs/GroupControllerSwagger.java
+++ b/motimo-api/src/main/java/kr/co/api/group/docs/GroupControllerSwagger.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import java.util.UUID;
+import kr.co.api.group.rqrs.GroupDetailRs;
 import kr.co.api.group.rqrs.GroupIdRs;
 import kr.co.api.group.rqrs.GroupJoinRq;
 import kr.co.api.group.rqrs.GroupMemberRs;
@@ -26,6 +27,9 @@ public interface GroupControllerSwagger {
 
     @Operation(summary = "참여중인 그룹 목록 API", description = "참여중인 그룹을 조회합니다.")
     List<JoinedGroupRs> getJoinedGroups(UUID userId);
+
+    @Operation(summary = "그룹 상세 조회 API", description = "그룹 아이디와 제목을 조회합니다.")
+    GroupDetailRs getGroupDetail(UUID userId, @PathVariable UUID groupId);
 
     @Operation(summary = "랜덤 그룹 가입 API", description = "랜덤으로 그룹에 가입합니다.")
     GroupIdRs joinRandomGroup(UUID userId, @RequestBody GroupJoinRq rq);

--- a/motimo-api/src/main/java/kr/co/api/group/docs/GroupControllerSwagger.java
+++ b/motimo-api/src/main/java/kr/co/api/group/docs/GroupControllerSwagger.java
@@ -25,7 +25,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 public interface GroupControllerSwagger {
 
     @Operation(summary = "참여중인 그룹 목록 API", description = "참여중인 그룹을 조회합니다.")
-    List<JoinedGroupRs> getJoinedGroup(UUID userId);
+    List<JoinedGroupRs> getJoinedGroups(UUID userId);
 
     @Operation(summary = "랜덤 그룹 가입 API", description = "랜덤으로 그룹에 가입합니다.")
     GroupIdRs joinRandomGroup(UUID userId, @RequestBody GroupJoinRq rq);

--- a/motimo-api/src/main/java/kr/co/api/group/rqrs/GroupDetailRs.java
+++ b/motimo-api/src/main/java/kr/co/api/group/rqrs/GroupDetailRs.java
@@ -1,0 +1,16 @@
+package kr.co.api.group.rqrs;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.UUID;
+import kr.co.api.group.service.dto.GroupDto;
+
+public record GroupDetailRs(
+        @Schema(description = "그룹 아이디", requiredMode = Schema.RequiredMode.REQUIRED)
+        UUID groupId,
+        @Schema(description = "그룹 이름 (현재는 목표와 동일)", requiredMode = Schema.RequiredMode.REQUIRED)
+        String name
+) {
+    public static GroupDetailRs from(GroupDto dto) {
+        return new GroupDetailRs(dto.groupId(), dto.name());
+    }
+}

--- a/motimo-api/src/main/java/kr/co/api/group/rqrs/GroupMemberRs.java
+++ b/motimo-api/src/main/java/kr/co/api/group/rqrs/GroupMemberRs.java
@@ -12,7 +12,7 @@ public record GroupMemberRs(
         String nickname,
         @Schema(description = "마지막 접속일", requiredMode = Schema.RequiredMode.REQUIRED)
         LocalDateTime lastOnlineDate,
-        @Schema(description = "찌르기 활성화 여부, 본인이면 null", requiredMode = Schema.RequiredMode.REQUIRED)
+        @Schema(description = "찌르기 활성화 여부, 본인이면 null")
         Boolean isActivePoke
 ) {
 

--- a/motimo-api/src/main/java/kr/co/api/group/rqrs/GroupMemberRs.java
+++ b/motimo-api/src/main/java/kr/co/api/group/rqrs/GroupMemberRs.java
@@ -3,6 +3,7 @@ package kr.co.api.group.rqrs;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.UUID;
+import kr.co.api.group.service.dto.GroupMemberDto;
 
 public record GroupMemberRs(
         @Schema(description = "사용자 아이디", requiredMode = Schema.RequiredMode.REQUIRED)
@@ -11,8 +12,16 @@ public record GroupMemberRs(
         String nickname,
         @Schema(description = "마지막 접속일", requiredMode = Schema.RequiredMode.REQUIRED)
         LocalDateTime lastOnlineDate,
-        @Schema(description = "찌르기 활성화 여부", requiredMode = Schema.RequiredMode.REQUIRED)
-        boolean isActivePoke
+        @Schema(description = "찌르기 활성화 여부, 본인이면 null", requiredMode = Schema.RequiredMode.REQUIRED)
+        Boolean isActivePoke
 ) {
 
+    public static GroupMemberRs from(GroupMemberDto dto) {
+        return new GroupMemberRs(
+                dto.memberId(),
+                dto.nickname(),
+                dto.lastOnlineDate(),
+                dto.isActivePoke()
+        );
+    }
 }

--- a/motimo-api/src/main/java/kr/co/api/group/rqrs/JoinedGroupRs.java
+++ b/motimo-api/src/main/java/kr/co/api/group/rqrs/JoinedGroupRs.java
@@ -9,7 +9,7 @@ public record JoinedGroupRs(
         @Schema(description = "그룹 아이디", requiredMode = Schema.RequiredMode.REQUIRED)
         UUID groupId,
         @Schema(description = "그룹 이름 (현재는 목표와 동일)", requiredMode = Schema.RequiredMode.REQUIRED)
-        String title,
+        String name,
         @Schema(description = "그룹 마지막 활동 날짜")
         LocalDateTime lastActiveDate,
         @Schema(description = "알림 활성화 여부 - 현재는 true 고정(미개발)", requiredMode = Schema.RequiredMode.REQUIRED)

--- a/motimo-api/src/main/java/kr/co/api/group/rqrs/JoinedGroupRs.java
+++ b/motimo-api/src/main/java/kr/co/api/group/rqrs/JoinedGroupRs.java
@@ -2,13 +2,26 @@ package kr.co.api.group.rqrs;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
+import java.util.UUID;
+import kr.co.api.group.service.dto.JoinedGroupDto;
 
 public record JoinedGroupRs(
+        @Schema(description = "그룹 아이디", requiredMode = Schema.RequiredMode.REQUIRED)
+        UUID groupId,
         @Schema(description = "그룹 이름 (현재는 목표와 동일)", requiredMode = Schema.RequiredMode.REQUIRED)
         String title,
         @Schema(description = "그룹 마지막 활동 날짜")
         LocalDateTime lastActiveDate,
-        @Schema(description = "알림 활성화 여부", requiredMode = Schema.RequiredMode.REQUIRED)
+        @Schema(description = "알림 활성화 여부 - 현재는 true 고정(미개발)", requiredMode = Schema.RequiredMode.REQUIRED)
         boolean isNotificationActive
 ) {
+
+    public static JoinedGroupRs from(JoinedGroupDto dto) {
+        return new JoinedGroupRs(
+                dto.groupId(),
+                dto.title(),
+                dto.lastActiveDate(),
+                dto.isNotificationAction()
+        );
+    }
 }

--- a/motimo-api/src/main/java/kr/co/api/group/service/GroupQueryService.java
+++ b/motimo-api/src/main/java/kr/co/api/group/service/GroupQueryService.java
@@ -20,7 +20,7 @@ public class GroupQueryService {
     private final GroupMessageRepository groupMessageRepository;
 
     public List<JoinedGroupDto> getJoinedGroupList(UUID userId) {
-        List<Group> groups = groupRepository.findAllByUserId(userId);
+        List<Group> groups = groupRepository.findAllGroupDetailByUserId(userId);
 
         return groups.stream().map(group -> {
             Optional<GroupMessage> groupLastMessage = groupMessageRepository.findLastGroupMessageByGroupId(group.getId());

--- a/motimo-api/src/main/java/kr/co/api/group/service/GroupQueryService.java
+++ b/motimo-api/src/main/java/kr/co/api/group/service/GroupQueryService.java
@@ -1,5 +1,13 @@
 package kr.co.api.group.service;
 
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import kr.co.api.group.service.dto.JoinedGroupDto;
+import kr.co.domain.group.Group;
+import kr.co.domain.group.message.GroupMessage;
+import kr.co.domain.group.message.repository.GroupMessageRepository;
+import kr.co.domain.group.repository.GroupRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -8,5 +16,20 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class GroupQueryService {
+    private final GroupRepository groupRepository;
+    private final GroupMessageRepository groupMessageRepository;
 
+    public List<JoinedGroupDto> getJoinedGroupList(UUID userId) {
+        List<Group> groups = groupRepository.findAllByUserId(userId);
+
+        return groups.stream().map(group -> {
+            Optional<GroupMessage> groupLastMessage = groupMessageRepository.findLastGroupMessageByGroupId(group.getId());
+            return new JoinedGroupDto(
+                    group.getId(),
+                    group.getName(),
+                    groupLastMessage.map(GroupMessage::getSendAt).orElse(null),
+                    true
+            );
+        }).toList();
+    }
 }

--- a/motimo-api/src/main/java/kr/co/api/group/service/GroupQueryService.java
+++ b/motimo-api/src/main/java/kr/co/api/group/service/GroupQueryService.java
@@ -3,11 +3,15 @@ package kr.co.api.group.service;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import kr.co.api.group.service.dto.GroupMemberDto;
 import kr.co.api.group.service.dto.JoinedGroupDto;
 import kr.co.domain.group.Group;
+import kr.co.domain.group.GroupMember;
 import kr.co.domain.group.message.GroupMessage;
 import kr.co.domain.group.message.repository.GroupMessageRepository;
+import kr.co.domain.group.repository.GroupMemberRepository;
 import kr.co.domain.group.repository.GroupRepository;
+import kr.co.domain.notification.repository.NotificationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,14 +20,18 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class GroupQueryService {
+
     private final GroupRepository groupRepository;
     private final GroupMessageRepository groupMessageRepository;
+    private final GroupMemberRepository groupMemberRepository;
+    private final NotificationRepository notificationRepository;
 
     public List<JoinedGroupDto> getJoinedGroupList(UUID userId) {
         List<Group> groups = groupRepository.findAllGroupDetailByUserId(userId);
 
         return groups.stream().map(group -> {
-            Optional<GroupMessage> groupLastMessage = groupMessageRepository.findLastGroupMessageByGroupId(group.getId());
+            Optional<GroupMessage> groupLastMessage = groupMessageRepository.findLastGroupMessageByGroupId(
+                    group.getId());
             return new JoinedGroupDto(
                     group.getId(),
                     group.getName(),
@@ -31,5 +39,21 @@ public class GroupQueryService {
                     true
             );
         }).toList();
+    }
+
+    public List<GroupMemberDto> getGroupMemberList(UUID userId, UUID groupId) {
+        List<GroupMember> groupMembers = groupMemberRepository.findAllByGroupId(groupId);
+
+        return groupMembers.stream()
+                .map(member -> {
+                    boolean isLoginUser = member.getMemberId().equals(userId);
+
+                    Boolean isActivePoke = isLoginUser ? null
+                            : !notificationRepository.existsByTodayPoke(userId, member.getMemberId(), groupId);
+
+                    return new GroupMemberDto(member.getMemberId(), member.getNickname(),
+                            member.getLastOnlineDate(), isActivePoke);
+                })
+                .toList();
     }
 }

--- a/motimo-api/src/main/java/kr/co/api/group/service/GroupQueryService.java
+++ b/motimo-api/src/main/java/kr/co/api/group/service/GroupQueryService.java
@@ -3,6 +3,7 @@ package kr.co.api.group.service;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import kr.co.api.group.service.dto.GroupDto;
 import kr.co.api.group.service.dto.GroupMemberDto;
 import kr.co.api.group.service.dto.JoinedGroupDto;
 import kr.co.domain.group.Group;
@@ -39,6 +40,11 @@ public class GroupQueryService {
                     true
             );
         }).toList();
+    }
+
+    public GroupDto getGroupDetail(UUID userId, UUID groupId) {
+        Group group = groupRepository.findDetailByGroupIdAndMemberId(userId, groupId);
+        return new GroupDto(group.getId(), group.getName());
     }
 
     public List<GroupMemberDto> getGroupMemberList(UUID userId, UUID groupId) {

--- a/motimo-api/src/main/java/kr/co/api/group/service/dto/GroupDto.java
+++ b/motimo-api/src/main/java/kr/co/api/group/service/dto/GroupDto.java
@@ -1,0 +1,10 @@
+package kr.co.api.group.service.dto;
+
+import java.util.UUID;
+
+public record GroupDto(
+        UUID groupId,
+        String name
+) {
+
+}

--- a/motimo-api/src/main/java/kr/co/api/group/service/dto/GroupMemberDto.java
+++ b/motimo-api/src/main/java/kr/co/api/group/service/dto/GroupMemberDto.java
@@ -1,0 +1,13 @@
+package kr.co.api.group.service.dto;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record GroupMemberDto(
+        UUID memberId,
+        String nickname,
+        LocalDateTime lastOnlineDate,
+        Boolean isActivePoke
+) {
+
+}

--- a/motimo-api/src/main/java/kr/co/api/group/service/dto/JoinedGroupDto.java
+++ b/motimo-api/src/main/java/kr/co/api/group/service/dto/JoinedGroupDto.java
@@ -1,0 +1,13 @@
+package kr.co.api.group.service.dto;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record JoinedGroupDto(
+        UUID groupId,
+        String title,
+        LocalDateTime lastActiveDate,
+        boolean isNotificationAction
+) {
+
+}

--- a/motimo-domain/src/main/java/kr/co/domain/group/Group.java
+++ b/motimo-domain/src/main/java/kr/co/domain/group/Group.java
@@ -22,6 +22,9 @@ public class Group {
     private UUID id = null;
 
     @Builder.Default()
+    private String name = null;
+
+    @Builder.Default()
     private List<GroupMember> members = new ArrayList<>();
 
     private LocalDateTime finishedDate;

--- a/motimo-domain/src/main/java/kr/co/domain/group/GroupMember.java
+++ b/motimo-domain/src/main/java/kr/co/domain/group/GroupMember.java
@@ -12,10 +12,11 @@ import lombok.Getter;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class GroupMember {
     private UUID memberId;
-    private String name;
+    private String nickname;
     private String email;
     private String profileImageUrl;
     private UUID goalId;
     private LocalDateTime joinedDate;
+    private LocalDateTime lastOnlineDate;
     private boolean isNotificationActive;
 }

--- a/motimo-domain/src/main/java/kr/co/domain/group/message/repository/GroupMessageRepository.java
+++ b/motimo-domain/src/main/java/kr/co/domain/group/message/repository/GroupMessageRepository.java
@@ -22,4 +22,5 @@ public interface GroupMessageRepository {
     void deleteAllByReferenceId(UUID referenceId);
 
     Optional<GroupMessage> findLastGroupMessageByGroupId(UUID groupId);
+
 }

--- a/motimo-domain/src/main/java/kr/co/domain/group/message/repository/GroupMessageRepository.java
+++ b/motimo-domain/src/main/java/kr/co/domain/group/message/repository/GroupMessageRepository.java
@@ -1,6 +1,7 @@
 package kr.co.domain.group.message.repository;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 import java.util.UUID;
 import kr.co.domain.common.pagination.CursorResult;
 import kr.co.domain.common.pagination.CustomCursor;
@@ -19,4 +20,6 @@ public interface GroupMessageRepository {
             UUID groupId, LocalDateTime latestDate, UUID latestMessageId);
 
     void deleteAllByReferenceId(UUID referenceId);
+
+    Optional<GroupMessage> findLastGroupMessageByGroupId(UUID groupId);
 }

--- a/motimo-domain/src/main/java/kr/co/domain/group/repository/GroupMemberRepository.java
+++ b/motimo-domain/src/main/java/kr/co/domain/group/repository/GroupMemberRepository.java
@@ -1,8 +1,11 @@
 package kr.co.domain.group.repository;
 
+import java.util.List;
 import java.util.UUID;
+import kr.co.domain.group.GroupMember;
 
 public interface GroupMemberRepository {
 
+    List<GroupMember> findAllByGroupId(UUID groupId);
     void deleteByGroupIdAndMemberId(UUID groupId, UUID userId);
 }

--- a/motimo-domain/src/main/java/kr/co/domain/group/repository/GroupRepository.java
+++ b/motimo-domain/src/main/java/kr/co/domain/group/repository/GroupRepository.java
@@ -1,6 +1,7 @@
 package kr.co.domain.group.repository;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import kr.co.domain.group.Group;
@@ -13,8 +14,12 @@ public interface GroupRepository {
     Group create(Group group);
 
     Group join(GroupJoinDto dto);
+
     Optional<Group> findByGoalId(UUID goalId);
+
     Optional<Group> findAvailableGroupBySimilarDueDate(UUID userId, LocalDate dueDate);
+
+    List<Group> findAllByUserId(UUID userId);
 
     boolean existsByGoalId(UUID goalId);
 

--- a/motimo-domain/src/main/java/kr/co/domain/group/repository/GroupRepository.java
+++ b/motimo-domain/src/main/java/kr/co/domain/group/repository/GroupRepository.java
@@ -19,7 +19,7 @@ public interface GroupRepository {
 
     Optional<Group> findAvailableGroupBySimilarDueDate(UUID userId, LocalDate dueDate);
 
-    List<Group> findAllByUserId(UUID userId);
+    List<Group> findAllGroupDetailByUserId(UUID userId);
 
     boolean existsByGoalId(UUID goalId);
 

--- a/motimo-domain/src/main/java/kr/co/domain/group/repository/GroupRepository.java
+++ b/motimo-domain/src/main/java/kr/co/domain/group/repository/GroupRepository.java
@@ -15,6 +15,8 @@ public interface GroupRepository {
 
     Group join(GroupJoinDto dto);
 
+    Group findDetailByGroupIdAndMemberId(UUID groupId, UUID memberId);
+
     Optional<Group> findByGoalId(UUID goalId);
 
     Optional<Group> findAvailableGroupBySimilarDueDate(UUID userId, LocalDate dueDate);

--- a/motimo-infra-rdb/src/main/java/kr/co/infra/rdb/group/entity/GroupEntity.java
+++ b/motimo-infra-rdb/src/main/java/kr/co/infra/rdb/group/entity/GroupEntity.java
@@ -28,7 +28,7 @@ public class GroupEntity extends BaseEntity {
     @GeneratedUuidV7Value
     private UUID id;
 
-    @OneToMany(fetch = FetchType.LAZY, mappedBy = "group", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "groupId", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<GroupMemberEntity> groupMembers;
 
     private LocalDateTime finishedDate;

--- a/motimo-infra-rdb/src/main/java/kr/co/infra/rdb/group/entity/GroupMemberEntity.java
+++ b/motimo-infra-rdb/src/main/java/kr/co/infra/rdb/group/entity/GroupMemberEntity.java
@@ -3,9 +3,7 @@ package kr.co.infra.rdb.group.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -34,8 +32,7 @@ public class GroupMemberEntity extends BaseEntity {
 
     private UUID goalId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    private GroupEntity group;
+    private UUID groupId;
 
     @CreatedDate
     @Column(updatable = false)
@@ -47,7 +44,7 @@ public class GroupMemberEntity extends BaseEntity {
     public GroupMemberEntity(UUID userId, UUID goalId, GroupEntity group, LocalDateTime joinedDate) {
         this.userId = userId;
         this.goalId = goalId;
-        this.group = group;
+        this.groupId = group.getId();
         this.joinedDate = joinedDate;
     }
 }

--- a/motimo-infra-rdb/src/main/java/kr/co/infra/rdb/group/message/repository/GroupMessageJpaRepository.java
+++ b/motimo-infra-rdb/src/main/java/kr/co/infra/rdb/group/message/repository/GroupMessageJpaRepository.java
@@ -1,5 +1,6 @@
 package kr.co.infra.rdb.group.message.repository;
 
+import java.util.Optional;
 import java.util.UUID;
 import kr.co.infra.rdb.group.message.GroupMessageEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,4 +9,5 @@ public interface GroupMessageJpaRepository extends JpaRepository<GroupMessageEnt
 
     void deleteAllByMessageReferenceReferenceId(UUID referenceId);
 
+    Optional<GroupMessageEntity> findTopByGroupIdOrderBySendAtDesc(UUID groupId);
 }

--- a/motimo-infra-rdb/src/main/java/kr/co/infra/rdb/group/message/repository/GroupMessageRepositoryImpl.java
+++ b/motimo-infra-rdb/src/main/java/kr/co/infra/rdb/group/message/repository/GroupMessageRepositoryImpl.java
@@ -122,6 +122,14 @@ public class GroupMessageRepositoryImpl implements GroupMessageRepository {
         groupMessageJpaRepository.deleteAllByMessageReferenceReferenceId(referenceId);
     }
 
+    @Override
+    public Optional<GroupMessage> findLastGroupMessageByGroupId(UUID groupId) {
+        Optional<GroupMessageEntity> groupMessageEntity = groupMessageJpaRepository.findTopByGroupIdOrderBySendAtDesc(
+                groupId);
+
+        return groupMessageEntity.map(GroupMessageMapper::toDomain);
+    }
+
     private List<GroupMessage> processMessagesWithReactions(List<GroupMessageEntity> messages) {
         if (messages.isEmpty()) {
             return List.of();

--- a/motimo-infra-rdb/src/main/java/kr/co/infra/rdb/group/repository/GroupMemberJpaRepository.java
+++ b/motimo-infra-rdb/src/main/java/kr/co/infra/rdb/group/repository/GroupMemberJpaRepository.java
@@ -44,6 +44,18 @@ public interface GroupMemberJpaRepository extends JpaRepository<GroupMemberEntit
                 JOIN goal_groups gr ON gm.group_id = gr.id
                 WHERE gm.user_id = :userId AND gm.is_deleted = false
             """, nativeQuery = true)
-    List<GroupMemberGoalGroupProjection> findGoalAndGroupInfoByUserId(@Param("userId") UUID userId);
+    List<GroupMemberGoalGroupProjection> findAllGoalAndGroupByUserId(@Param("userId") UUID userId);
 
+    @Query(value = """
+                SELECT 
+                    gm.goal_id AS goalId,
+                    g.title AS goalTitle,
+                    gm.group_id AS groupId,
+                    gr.finished_date AS groupFinishedDate
+                FROM group_members gm
+                JOIN goals g ON gm.goal_id = g.id
+                JOIN goal_groups gr ON gm.group_id = gr.id
+                WHERE gm.user_id = :userId AND gr.id = :groupId AND gm.is_deleted = false 
+            """, nativeQuery = true)
+    GroupMemberGoalGroupProjection findGoalAndGroupByUserIdAndGroupId(@Param("userId") UUID userId, @Param("groupId") UUID groupId);
 }

--- a/motimo-infra-rdb/src/main/java/kr/co/infra/rdb/group/repository/GroupMemberJpaRepository.java
+++ b/motimo-infra-rdb/src/main/java/kr/co/infra/rdb/group/repository/GroupMemberJpaRepository.java
@@ -24,7 +24,7 @@ public interface GroupMemberJpaRepository extends JpaRepository<GroupMemberEntit
                     gm.goal_id AS goalId,
                     g.title AS goalTitle,
                     gm.group_id AS groupId,
-                    gr.created_at AS groupCreatedAt
+                    gr.finished_date AS groupFinishedDate
                 FROM group_members gm
                 JOIN goals g ON gm.goal_id = g.id
                 JOIN goal_groups gr ON gm.group_id = gr.id

--- a/motimo-infra-rdb/src/main/java/kr/co/infra/rdb/group/repository/GroupMemberJpaRepository.java
+++ b/motimo-infra-rdb/src/main/java/kr/co/infra/rdb/group/repository/GroupMemberJpaRepository.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import java.util.UUID;
 import kr.co.infra.rdb.group.entity.GroupMemberEntity;
 import kr.co.infra.rdb.group.repository.projection.GroupMemberGoalGroupProjection;
+import kr.co.infra.rdb.group.repository.projection.GroupMemberUserProjection;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -17,7 +18,20 @@ public interface GroupMemberJpaRepository extends JpaRepository<GroupMemberEntit
 
     Optional<GroupMemberEntity> findByGoalId(UUID goalId);
 
-    List<GroupMemberEntity> findByUserId(UUID userId);
+    @Query(value = """
+                SELECT 
+                  gm.user_id AS memberId,
+                  gm.goal_id AS goalId,
+                  u.nickname AS nickname,
+                  u.email AS email,
+                  u.profile_image_url AS profileImageUrl,
+                  gm.joined_date AS joinedDate,
+                  gm.is_notification_active AS isNotificationActive
+                FROM group_members gm
+                JOIN users u ON gm.user_id = u.id
+                WHERE gm.group_id = :groupId AND gm.is_deleted = false
+            """, nativeQuery = true)
+    List<GroupMemberUserProjection> findByGroupId(@Param("groupId") UUID groupId);
 
     @Query(value = """
                 SELECT 

--- a/motimo-infra-rdb/src/main/java/kr/co/infra/rdb/group/repository/GroupMemberJpaRepository.java
+++ b/motimo-infra-rdb/src/main/java/kr/co/infra/rdb/group/repository/GroupMemberJpaRepository.java
@@ -1,9 +1,13 @@
 package kr.co.infra.rdb.group.repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import kr.co.infra.rdb.group.entity.GroupMemberEntity;
+import kr.co.infra.rdb.group.repository.projection.GroupMemberGoalGroupProjection;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface GroupMemberJpaRepository extends JpaRepository<GroupMemberEntity, UUID> {
 
@@ -12,4 +16,20 @@ public interface GroupMemberJpaRepository extends JpaRepository<GroupMemberEntit
     void deleteByGroupIdAndUserId(UUID groupId, UUID userId);
 
     Optional<GroupMemberEntity> findByGoalId(UUID goalId);
+
+    List<GroupMemberEntity> findByUserId(UUID userId);
+
+    @Query(value = """
+                SELECT 
+                    gm.goal_id AS goalId,
+                    g.title AS goalTitle,
+                    gm.group_id AS groupId,
+                    gr.created_at AS groupCreatedAt
+                FROM group_members gm
+                JOIN goals g ON gm.goal_id = g.id
+                JOIN goal_groups gr ON gm.group_id = gr.id
+                WHERE gm.user_id = :userId AND gm.is_deleted = false
+            """, nativeQuery = true)
+    List<GroupMemberGoalGroupProjection> findGoalAndGroupInfoByUserId(@Param("userId") UUID userId);
+
 }

--- a/motimo-infra-rdb/src/main/java/kr/co/infra/rdb/group/repository/GroupMemberRepositoryImpl.java
+++ b/motimo-infra-rdb/src/main/java/kr/co/infra/rdb/group/repository/GroupMemberRepositoryImpl.java
@@ -1,8 +1,12 @@
 package kr.co.infra.rdb.group.repository;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
 import java.util.UUID;
+import kr.co.domain.group.GroupMember;
 import kr.co.domain.group.repository.GroupMemberRepository;
+import kr.co.infra.rdb.group.repository.projection.GroupMemberUserProjection;
+import kr.co.infra.rdb.group.util.GroupMemberMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -12,6 +16,12 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepository {
 
     private final GroupMemberJpaRepository groupMemberJpaRepository;
     private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<GroupMember> findAllByGroupId(UUID groupId) {
+        List<GroupMemberUserProjection> groupMemberEntities = groupMemberJpaRepository.findByGroupId(groupId);
+        return groupMemberEntities.stream().map(GroupMemberMapper::toDomain).toList();
+    }
 
     @Override
     public void deleteByGroupIdAndMemberId(UUID groupId, UUID userId) {

--- a/motimo-infra-rdb/src/main/java/kr/co/infra/rdb/group/repository/GroupRepositoryImpl.java
+++ b/motimo-infra-rdb/src/main/java/kr/co/infra/rdb/group/repository/GroupRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import kr.co.domain.group.Group;
@@ -15,6 +16,7 @@ import kr.co.infra.rdb.group.entity.GroupEntity;
 import kr.co.infra.rdb.group.entity.GroupMemberEntity;
 import kr.co.infra.rdb.group.entity.QGroupEntity;
 import kr.co.infra.rdb.group.entity.QGroupMemberEntity;
+import kr.co.infra.rdb.group.repository.projection.GroupMemberGoalGroupProjection;
 import kr.co.infra.rdb.group.repository.query.GroupJpaSubQuery;
 import kr.co.infra.rdb.group.util.GroupMapper;
 import lombok.RequiredArgsConstructor;
@@ -88,6 +90,16 @@ public class GroupRepositoryImpl implements GroupRepository {
                 .fetchOne();
 
         return result == null ? Optional.empty() : Optional.of(GroupMapper.toDomain(result));
+    }
+
+    @Override
+    public List<Group> findAllByUserId(UUID userId) {
+        List<GroupMemberGoalGroupProjection> groupProjections = groupMemberJpaRepository.findGoalAndGroupInfoByUserId(
+                userId);
+
+        return groupProjections.stream()
+                .map(projection -> GroupMapper.toDomainWithName(projection.getGroupId(),
+                        projection.getGoalTitle(), projection.getGroupFinishedDate())).toList();
     }
 
     @Override

--- a/motimo-infra-rdb/src/main/java/kr/co/infra/rdb/group/repository/GroupRepositoryImpl.java
+++ b/motimo-infra-rdb/src/main/java/kr/co/infra/rdb/group/repository/GroupRepositoryImpl.java
@@ -63,6 +63,12 @@ public class GroupRepositoryImpl implements GroupRepository {
         return GroupMapper.toDomain(groupEntity);
     }
 
+    public Group findDetailByGroupIdAndMemberId(UUID groupId, UUID memberId) {
+        GroupMemberGoalGroupProjection projection = groupMemberJpaRepository.findGoalAndGroupByUserIdAndGroupId(memberId, groupId);
+
+        return GroupMapper.toDomainWithName(projection.getGroupId(), projection.getGoalTitle(), projection.getGroupFinishedDate());
+    }
+
     public Optional<Group> findByGoalId(UUID goalId) {
         Optional<GroupMemberEntity> groupMemberEntity = groupMemberJpaRepository.findByGoalId(
                 goalId);
@@ -99,7 +105,7 @@ public class GroupRepositoryImpl implements GroupRepository {
 
     @Override
     public List<Group> findAllGroupDetailByUserId(UUID userId) {
-        List<GroupMemberGoalGroupProjection> groupProjections = groupMemberJpaRepository.findGoalAndGroupInfoByUserId(
+        List<GroupMemberGoalGroupProjection> groupProjections = groupMemberJpaRepository.findAllGoalAndGroupByUserId(
                 userId);
 
         return groupProjections.stream()

--- a/motimo-infra-rdb/src/main/java/kr/co/infra/rdb/group/repository/GroupRepositoryImpl.java
+++ b/motimo-infra-rdb/src/main/java/kr/co/infra/rdb/group/repository/GroupRepositoryImpl.java
@@ -98,7 +98,7 @@ public class GroupRepositoryImpl implements GroupRepository {
     }
 
     @Override
-    public List<Group> findAllByUserId(UUID userId) {
+    public List<Group> findAllGroupDetailByUserId(UUID userId) {
         List<GroupMemberGoalGroupProjection> groupProjections = groupMemberJpaRepository.findGoalAndGroupInfoByUserId(
                 userId);
 

--- a/motimo-infra-rdb/src/main/java/kr/co/infra/rdb/group/repository/GroupRepositoryImpl.java
+++ b/motimo-infra-rdb/src/main/java/kr/co/infra/rdb/group/repository/GroupRepositoryImpl.java
@@ -66,8 +66,13 @@ public class GroupRepositoryImpl implements GroupRepository {
     public Optional<Group> findByGoalId(UUID goalId) {
         Optional<GroupMemberEntity> groupMemberEntity = groupMemberJpaRepository.findByGoalId(
                 goalId);
-        return groupMemberEntity.map(memberEntity -> GroupMapper.toDomain(memberEntity
-                .getGroup()));
+
+        return groupMemberEntity.map(memberEntity -> {
+            GroupEntity groupEntity = groupJpaRepository.findById(memberEntity.getGroupId())
+                    .orElseThrow(GroupNotFoundException::new);
+
+            return GroupMapper.toDomain(groupEntity);
+        });
     }
 
     public Optional<Group> findAvailableGroupBySimilarDueDate(UUID userId, LocalDate dueDate) {

--- a/motimo-infra-rdb/src/main/java/kr/co/infra/rdb/group/repository/projection/GroupMemberGoalGroupProjection.java
+++ b/motimo-infra-rdb/src/main/java/kr/co/infra/rdb/group/repository/projection/GroupMemberGoalGroupProjection.java
@@ -1,0 +1,11 @@
+package kr.co.infra.rdb.group.repository.projection;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public interface GroupMemberGoalGroupProjection {
+    UUID getGoalId();
+    String getGoalTitle();
+    UUID getGroupId();
+    LocalDateTime getGroupFinishedDate();
+}

--- a/motimo-infra-rdb/src/main/java/kr/co/infra/rdb/group/repository/projection/GroupMemberUserProjection.java
+++ b/motimo-infra-rdb/src/main/java/kr/co/infra/rdb/group/repository/projection/GroupMemberUserProjection.java
@@ -1,0 +1,14 @@
+package kr.co.infra.rdb.group.repository.projection;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public interface GroupMemberUserProjection {
+    UUID getMemberId();
+    UUID getGoalId();
+    String getNickname();
+    String getEmail();
+    String getProfileImageUrl();
+    LocalDateTime getJoinedDate();
+    boolean isNotificationActive();
+}

--- a/motimo-infra-rdb/src/main/java/kr/co/infra/rdb/group/repository/projection/GroupMemberUserProjection.java
+++ b/motimo-infra-rdb/src/main/java/kr/co/infra/rdb/group/repository/projection/GroupMemberUserProjection.java
@@ -10,5 +10,5 @@ public interface GroupMemberUserProjection {
     String getEmail();
     String getProfileImageUrl();
     LocalDateTime getJoinedDate();
-    boolean isNotificationActive();
+    boolean getIsNotificationActive();
 }

--- a/motimo-infra-rdb/src/main/java/kr/co/infra/rdb/group/repository/query/GroupJpaSubQuery.java
+++ b/motimo-infra-rdb/src/main/java/kr/co/infra/rdb/group/repository/query/GroupJpaSubQuery.java
@@ -27,14 +27,14 @@ public class GroupJpaSubQuery {
         return jpaQueryFactory
                 .select(member.count())
                 .from(member)
-                .where(member.group.id.eq(group.id));
+                .where(member.groupId.eq(group.id));
     }
 
     public BooleanExpression userNotInGroup(UUID userId, QGroupEntity group,
             QGroupMemberEntity member) {
         return group.id.notIn(
                 JPAExpressions
-                        .select(member.group.id)
+                        .select(member.groupId)
                         .from(member)
                         .where(member.userId.eq(userId))
         );
@@ -57,7 +57,7 @@ public class GroupJpaSubQuery {
                 .select(extractDayOfYear(goal.dueDate.dueDate).avg())
                 .from(member)
                 .join(goal).on(member.goalId.eq(goal.id))
-                .where(member.group.id.eq(group.id));
+                .where(member.groupId.eq(group.id));
 
         return Expressions.numberTemplate(Double.class, "({0})", subquery);
     }

--- a/motimo-infra-rdb/src/main/java/kr/co/infra/rdb/group/util/GroupMapper.java
+++ b/motimo-infra-rdb/src/main/java/kr/co/infra/rdb/group/util/GroupMapper.java
@@ -1,5 +1,7 @@
 package kr.co.infra.rdb.group.util;
 
+import java.time.LocalDateTime;
+import java.util.UUID;
 import kr.co.domain.group.Group;
 import kr.co.infra.rdb.group.entity.GroupEntity;
 import lombok.experimental.UtilityClass;
@@ -11,6 +13,14 @@ public class GroupMapper {
         return Group.builder()
                 .id(entity.getId())
                 .finishedDate(entity.getFinishedDate())
+                .build();
+    }
+
+    public static Group toDomainWithName(UUID groupId, String name, LocalDateTime finishedDate) {
+        return Group.builder()
+                .id(groupId)
+                .name(name)
+                .finishedDate(finishedDate)
                 .build();
     }
 

--- a/motimo-infra-rdb/src/main/java/kr/co/infra/rdb/group/util/GroupMemberMapper.java
+++ b/motimo-infra-rdb/src/main/java/kr/co/infra/rdb/group/util/GroupMemberMapper.java
@@ -1,7 +1,9 @@
 package kr.co.infra.rdb.group.util;
 
+import java.time.LocalDateTime;
 import kr.co.domain.group.GroupMember;
 import kr.co.infra.rdb.group.entity.GroupMemberEntity;
+import kr.co.infra.rdb.group.repository.projection.GroupMemberUserProjection;
 import kr.co.infra.rdb.user.entity.UserEntity;
 
 public class GroupMemberMapper {
@@ -9,10 +11,23 @@ public class GroupMemberMapper {
         return GroupMember.builder()
                 .memberId(entity.getUserId())
                 .goalId(entity.getGoalId())
-                .name(user.getNickname())
+                .nickname(user.getNickname())
                 .email(user.getEmail())
                 .profileImageUrl(user.getProfileImageUrl())
                 .joinedDate(entity.getJoinedDate())
+                .lastOnlineDate(LocalDateTime.now())
                 .isNotificationActive(entity.isNotificationActive()).build();
+    }
+
+    public static GroupMember toDomain(GroupMemberUserProjection projection) {
+        return GroupMember.builder()
+                .memberId(projection.getMemberId())
+                .goalId(projection.getGoalId())
+                .nickname(projection.getNickname())
+                .email(projection.getEmail())
+                .profileImageUrl(projection.getProfileImageUrl())
+                .joinedDate(projection.getJoinedDate())
+                .lastOnlineDate(LocalDateTime.now())
+                .isNotificationActive(projection.isNotificationActive()).build();
     }
 }

--- a/motimo-infra-rdb/src/main/java/kr/co/infra/rdb/group/util/GroupMemberMapper.java
+++ b/motimo-infra-rdb/src/main/java/kr/co/infra/rdb/group/util/GroupMemberMapper.java
@@ -28,6 +28,6 @@ public class GroupMemberMapper {
                 .profileImageUrl(projection.getProfileImageUrl())
                 .joinedDate(projection.getJoinedDate())
                 .lastOnlineDate(LocalDateTime.now())
-                .isNotificationActive(projection.isNotificationActive()).build();
+                .isNotificationActive(projection.getIsNotificationActive()).build();
     }
 }

--- a/motimo-infra-rdb/src/test/java/kr/co/infra/rdb/group/GroupRepositoryTest.java
+++ b/motimo-infra-rdb/src/test/java/kr/co/infra/rdb/group/GroupRepositoryTest.java
@@ -1,7 +1,10 @@
 package kr.co.infra.rdb.group;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
 
+import com.querydsl.core.types.dsl.Expressions;
 import jakarta.transaction.Transactional;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -26,6 +29,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 @DataJpaTest
 @ActiveProfiles("test")
@@ -44,10 +48,18 @@ class GroupRepositoryTest {
     private static final int MAX_GROUP_COUNT = 6;
     private LocalDate standardDueDate;
 
+    @MockitoSpyBean
+    private GroupJpaSubQuery groupJpaSubQuery;
+
     @BeforeEach
     void setUp() {
         testUserId = UUID.randomUUID();
         standardDueDate = LocalDate.of(2024, 6, 15);
+
+        // 날짜 관련 코드 비활성화
+        doReturn(Expressions.TRUE)
+                .when(groupJpaSubQuery)
+                .hasSimilarDueDate(any(), any(), any(), any());
     }
 
     @Test
@@ -131,8 +143,8 @@ class GroupRepositoryTest {
         assertThat(result).isEmpty();
     }
 
-    @Test
-    @DisplayName("평균 완료날짜와 30일 초과 차이나는 그룹은 제외")
+//    @Test
+    @DisplayName("평균 완료날짜와 30일 초과 차이나는 그룹은 제외 - 날짜 관련 코드가 postgres 전용이므로 테스트코드 동작하지 않음")
     void 평균_완료_날짜와_30일_초과_차이나는_그룹_제외() {
         // Given
         GroupEntity group = createGroup();

--- a/motimo-infra-rdb/src/test/java/kr/co/infra/rdb/group/GroupRepositoryTest.java
+++ b/motimo-infra-rdb/src/test/java/kr/co/infra/rdb/group/GroupRepositoryTest.java
@@ -21,6 +21,7 @@ import kr.co.infra.rdb.group.entity.GroupMemberEntity;
 import kr.co.infra.rdb.group.repository.GroupRepositoryImpl;
 import kr.co.infra.rdb.group.repository.query.GroupJpaSubQuery;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -143,7 +144,8 @@ class GroupRepositoryTest {
         assertThat(result).isEmpty();
     }
 
-//    @Test
+    @Disabled
+    @Test
     @DisplayName("평균 완료날짜와 30일 초과 차이나는 그룹은 제외 - 날짜 관련 코드가 postgres 전용이므로 테스트코드 동작하지 않음")
     void 평균_완료_날짜와_30일_초과_차이나는_그룹_제외() {
         // Given


### PR DESCRIPTION
## 📌 관련 이슈
#57 
<br>

## ✨ 작업 개요
- 참여한 그룹 조회 API
- 그룹 멤버 조회 API
- 그룹 상세 조회 API
<br>

## ✅ 작업 상세 내용
- 그룹 도메인에 그룹 이름 추가
- GroupMember -> Group간의 `@ManyToOne` 관계 삭제 (OneToMany도 삭제 예정)
<br>

## 💬 기타 참고 사항
- 참여한 그룹 조회 시 그룹/목표와의 조인이 필요해서 nativeQuery 사용
- 그룹 레포지토리 테스트 코드에서 postgres 쿼리 사용 부분 비활성화
    - `;MODE=PostgreSQL` h2 모드 변경을 사용하려고 했으나 잘 안되는 것 같더라구요 ;.; 다른 방법 있는지 알아보겠습니다
- `lastLoginAt` 추가는 다른 브랜치에서 진행하겠습니당
<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can now view detailed information for each group they belong to.
  * Group member details include last online date and dynamic poke notification status.
  * Latest group messages are accessible to provide context in group views.
* **Improvements**
  * Group lists and member data are dynamically fetched and updated for accuracy.
  * Group member profiles now include nicknames and enhanced metadata.
  * Internal data handling optimized for consistent group membership and activity tracking.
* **Bug Fixes**
  * Fixed group membership and message retrieval associations for reliability.
* **Tests**
  * Enhanced test coverage with adjustments for database-specific behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->