### PR TITLE
#60 feat: 메시지 리액션 생성/삭제 API

### DIFF
--- a/motimo-api/src/main/java/kr/co/api/group/GroupController.java
+++ b/motimo-api/src/main/java/kr/co/api/group/GroupController.java
@@ -14,6 +14,7 @@ import kr.co.api.group.rqrs.message.NewMessageRs;
 import kr.co.api.group.service.GroupCommandService;
 import kr.co.api.group.service.GroupMessageQueryService;
 import kr.co.api.group.service.GroupQueryService;
+import kr.co.api.group.service.ReactionCommandService;
 import kr.co.api.security.annotation.AuthUser;
 import kr.co.domain.common.pagination.PagingDirection;
 import kr.co.domain.group.reaction.ReactionType;
@@ -36,13 +37,16 @@ public class GroupController implements GroupControllerSwagger {
     private final GroupMessageQueryService groupMessageQueryService;
     private final GroupCommandService groupCommandService;
     private final GroupQueryService groupQueryService;
+    private final ReactionCommandService reactionCommandService;
 
     public GroupController(final GroupMessageQueryService groupMessageQueryService,
             final GroupCommandService groupCommandService,
-            final GroupQueryService groupQueryService) {
+            final GroupQueryService groupQueryService,
+            final ReactionCommandService reactionCommandService) {
         this.groupMessageQueryService = groupMessageQueryService;
         this.groupCommandService = groupCommandService;
         this.groupQueryService = groupQueryService;
+        this.reactionCommandService = reactionCommandService;
     }
 
     @GetMapping("/me")
@@ -85,7 +89,13 @@ public class GroupController implements GroupControllerSwagger {
     @PostMapping("/message/{messageId}/reaction")
     public GroupMessageIdRs createGroupReaction(@AuthUser UUID userId, @PathVariable UUID messageId,
             @RequestParam ReactionType type) {
-        return new GroupMessageIdRs(UUID.randomUUID());
+        return new GroupMessageIdRs(reactionCommandService.createReaction(userId, messageId, type));
+    }
+
+    @DeleteMapping("/message/{messageId}/reaction")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void createGroupReaction(@AuthUser UUID userId, @PathVariable UUID messageId) {
+        reactionCommandService.deleteReaction(userId, messageId);
     }
 
     @GetMapping("/{groupId}/members")

--- a/motimo-api/src/main/java/kr/co/api/group/service/GroupMessageQueryService.java
+++ b/motimo-api/src/main/java/kr/co/api/group/service/GroupMessageQueryService.java
@@ -33,6 +33,7 @@ public class GroupMessageQueryService {
     private final GroupMessageRepository groupMessageRepository;
     private final MessageContentLoader contentLoader;
     private final MessageContentStrategyFactory strategyFactory;
+
     private final CursorUtil cursorUtil;
 
     public GroupChatDto findMessagesByGroupIdWithCursor(UUID userId, UUID groupId,

--- a/motimo-api/src/main/java/kr/co/api/group/service/GroupQueryService.java
+++ b/motimo-api/src/main/java/kr/co/api/group/service/GroupQueryService.java
@@ -30,6 +30,7 @@ public class GroupQueryService {
     public List<JoinedGroupDto> getJoinedGroupList(UUID userId) {
         List<Group> groups = groupRepository.findAllGroupDetailByUserId(userId);
 
+        System.out.println("here");
         return groups.stream().map(group -> {
             Optional<GroupMessage> groupLastMessage = groupMessageRepository.findLastGroupMessageByGroupId(
                     group.getId());

--- a/motimo-api/src/main/java/kr/co/api/group/service/ReactionCommandService.java
+++ b/motimo-api/src/main/java/kr/co/api/group/service/ReactionCommandService.java
@@ -1,0 +1,32 @@
+package kr.co.api.group.service;
+
+import java.util.UUID;
+import kr.co.domain.group.reaction.Reaction;
+import kr.co.domain.group.reaction.ReactionType;
+import kr.co.domain.group.reaction.repository.ReactionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ReactionCommandService {
+
+    private final ReactionRepository reactionRepository;
+
+    public UUID createReaction(UUID userId, UUID messageId, ReactionType type) {
+        // TODO 그룹 메시지 발행
+
+        Reaction reaction = reactionRepository.create(Reaction.createReaction()
+                .userId(userId)
+                .messageId(messageId)
+                .reactionType(type).build());
+
+        return reaction.getId();
+    }
+
+    public void deleteReaction(UUID userId, UUID messageId) {
+        reactionRepository.deleteByUserIdAndMessageId(userId, messageId);
+    }
+}

--- a/motimo-domain/src/main/java/kr/co/domain/group/reaction/Reaction.java
+++ b/motimo-domain/src/main/java/kr/co/domain/group/reaction/Reaction.java
@@ -13,7 +13,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Reaction {
-
     @Builder.Default
     private UUID id = null;
     private UUID userId;
@@ -21,4 +20,11 @@ public class Reaction {
     private ReactionType reactionType;
     @Builder.Default
     private LocalDateTime createdAt = LocalDateTime.now();
+
+    @Builder(builderMethodName = "createReaction")
+    private Reaction(UUID userId, UUID messageId, ReactionType reactionType) {
+        this.userId = userId;
+        this.messageId = messageId;
+        this.reactionType = reactionType;
+    }
 }

--- a/motimo-domain/src/main/java/kr/co/domain/group/reaction/repository/ReactionRepository.java
+++ b/motimo-domain/src/main/java/kr/co/domain/group/reaction/repository/ReactionRepository.java
@@ -1,0 +1,13 @@
+package kr.co.domain.group.reaction.repository;
+
+import java.util.UUID;
+import kr.co.domain.group.reaction.Reaction;
+
+public interface ReactionRepository {
+
+    Reaction create(Reaction reaction);
+
+    void delete(UUID reactionId);
+
+    void deleteByUserIdAndMessageId(UUID userId, UUID messageId);
+}

--- a/motimo-infra-rdb/src/main/java/kr/co/infra/rdb/group/reaction/repository/ReactionJpaRepository.java
+++ b/motimo-infra-rdb/src/main/java/kr/co/infra/rdb/group/reaction/repository/ReactionJpaRepository.java
@@ -1,0 +1,9 @@
+package kr.co.infra.rdb.group.reaction.repository;
+
+import java.util.UUID;
+import kr.co.infra.rdb.group.reaction.ReactionEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReactionJpaRepository extends JpaRepository<ReactionEntity, UUID> {
+    void deleteByUserIdAndMessageId(UUID userId, UUID messageId);
+}

--- a/motimo-infra-rdb/src/main/java/kr/co/infra/rdb/group/reaction/repository/ReactionRepositoryImpl.java
+++ b/motimo-infra-rdb/src/main/java/kr/co/infra/rdb/group/reaction/repository/ReactionRepositoryImpl.java
@@ -1,0 +1,33 @@
+package kr.co.infra.rdb.group.reaction.repository;
+
+import java.util.UUID;
+import kr.co.domain.group.reaction.Reaction;
+import kr.co.domain.group.reaction.repository.ReactionRepository;
+import kr.co.infra.rdb.group.reaction.ReactionEntity;
+import kr.co.infra.rdb.group.reaction.ReactionMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ReactionRepositoryImpl implements ReactionRepository {
+
+    private final ReactionJpaRepository reactionJpaRepository;
+
+    @Override
+    public Reaction create(Reaction reaction) {
+        ReactionEntity reactionEntity = reactionJpaRepository.save(
+                ReactionMapper.toEntity(reaction));
+        return ReactionMapper.toDomain(reactionEntity);
+    }
+
+    @Override
+    public void delete(UUID reactionId) {
+        reactionJpaRepository.deleteById(reactionId);
+    }
+
+    @Override
+    public void deleteByUserIdAndMessageId(UUID userId, UUID messageId) {
+        reactionJpaRepository.deleteByUserIdAndMessageId(userId, messageId);
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
#60 
<br>

## 💬 기타 참고 사항
- GroupController와 GroupMessageController 분리하려고 하는데 확인해주시면 분리하겠습니다
<br>

## 🔍 고민 지점
- 지금 todo 삭제 시 그룹 메세지에 content null로 나오게 되어있는 것 같은데 맞을까요?
- 리액션 구현을 어떻게 해야할지 고민했는데 우선 투두와 동일하게 구현해두려고 합니다
    - 첫번째 구현 방안: 메세지 Ref를 리액션 한 메세지의 Ref 타입과 동일하게 하려고 했음/또는 null로 두거나/메세지 그 자체로 두거나 -> 그런데 이렇게 하면 '리액션 타입'을 따로 저장해주어야 함 -> 메세지 엔티티에 '고정된 컨텐츠' 필드를 추가한다
        ```GroupMessage newGroupMessage = GroupMessage.createGroupMessage()
                .groupId(groupMessage.getGroupId())
                .userId(event.getUserId())
                .messageType(GroupMessageType.MESSAGE_REACTION)
                .messageReference(
                        groupMessage.getMessageReference()
                )
                .build();
    - 두번째 구현 방안: 메세지 Ref를 리액션으로 둔다 -> 이러면 리액션이 삭제 되었을 경우 대처가 어려움 -> 그런데 todo 처럼 없다면 어떤 리액션인지 content를 안 보여주는 방안으로 하면 해결 가능

-> 리액션 관련 그룹 메시지 발행 부분은 내일 구현할게용 이거 고민하다가 오늘 시간을 너무 잡아먹었네욤...