### PR TITLE
feat: 목표 + 세부목표 + 미완료 or 오늘의 투두 조회하는 api 추가

### DIFF
--- a/motimo-api/src/main/java/kr/co/api/config/SecurityConfig.java
+++ b/motimo-api/src/main/java/kr/co/api/config/SecurityConfig.java
@@ -76,7 +76,9 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/login").permitAll()
                         .requestMatchers(HttpMethod.POST, "/v1/auth/reissue").permitAll()
                         .requestMatchers(HttpMethod.GET, "/v1/todos/{todoId}/result").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/v1/goals/{goals}").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/v1/goals/{goalId}").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/v1/goals/{goalId}/sub-goals/all")
+                        .permitAll()
                         .requestMatchers(HttpMethod.GET, "/v1/sub-goals/{subGoalId}/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/v1/users/{userId}").permitAll()
 

--- a/motimo-api/src/main/java/kr/co/api/goal/GoalReadController.java
+++ b/motimo-api/src/main/java/kr/co/api/goal/GoalReadController.java
@@ -10,6 +10,7 @@ import kr.co.api.goal.rqrs.GoalItemRs;
 import kr.co.api.goal.rqrs.GoalListRs;
 import kr.co.api.goal.rqrs.GoalNotInGroupRs;
 import kr.co.api.goal.rqrs.GoalWithSubGoalRs;
+import kr.co.api.goal.rqrs.GoalWithSubGoalTodoRs;
 import kr.co.api.goal.service.GoalQueryService;
 import kr.co.api.security.annotation.AuthUser;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -46,6 +47,12 @@ public class GoalReadController implements GoalReadControllerSwagger {
     @GetMapping("/{goalId}/sub-goals")
     public GoalWithSubGoalRs getGoalWithSubGoal(@PathVariable UUID goalId) {
         return GoalWithSubGoalRs.from(goalQueryService.getGoalWithSubGoal(goalId));
+    }
+
+    @GetMapping("/{goalId}/sub-goals/all")
+    public GoalWithSubGoalTodoRs getGoalWithSubGoalAndTodos(@PathVariable UUID goalId) {
+        return GoalWithSubGoalTodoRs.from(
+                goalQueryService.getGoalWithIncompleteSubGoalTodayTodos(goalId));
     }
 
     @GetMapping("/not-joined-group")

--- a/motimo-api/src/main/java/kr/co/api/goal/docs/GoalReadControllerSwagger.java
+++ b/motimo-api/src/main/java/kr/co/api/goal/docs/GoalReadControllerSwagger.java
@@ -1,6 +1,7 @@
 package kr.co.api.goal.docs;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -13,6 +14,7 @@ import kr.co.api.goal.rqrs.GoalDetailRs;
 import kr.co.api.goal.rqrs.GoalListRs;
 import kr.co.api.goal.rqrs.GoalNotInGroupRs;
 import kr.co.api.goal.rqrs.GoalWithSubGoalRs;
+import kr.co.api.goal.rqrs.GoalWithSubGoalTodoRs;
 import org.springframework.web.bind.annotation.PathVariable;
 
 @Tag(name = "목표 API", description = "목표 관련 API 목록입니다")
@@ -30,6 +32,20 @@ public interface GoalReadControllerSwagger {
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", content = @Content),
     })
     CompletedGoalListRs getCompletedGoals(UUID userId);
+
+    @Operation(
+            summary = "목표 + 세부목표 + 오늘의 미완료 투두 조회 API",
+            description = "목표 ID에 해당하는 목표 정보와 모든 세부 목표 및 오늘의 미완료 투두 목록을 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "목표, 세부목표, 오늘의 미완료 투두 목록 반환", content = @Content(schema = @Schema(implementation = GoalWithSubGoalTodoRs.class))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", content = @Content),
+            @ApiResponse(responseCode = "404", description = "해당 목표를 찾을 수 없음", content = @Content)
+    })
+    GoalWithSubGoalTodoRs getGoalWithSubGoalAndTodos(
+            @Parameter(description = "목표 ID", required = true, example = "123e4567-e89b-12d3-a456-426614174000")
+            @PathVariable UUID goalId
+    );
 
     @Operation(summary = "목표와 세부목표 목록 API", description = "목표와 세부 목표 리스트를 조회합니다.")
     @ApiResponses({

--- a/motimo-api/src/main/java/kr/co/api/goal/dto/GoalWithSubGoalTodoDto.java
+++ b/motimo-api/src/main/java/kr/co/api/goal/dto/GoalWithSubGoalTodoDto.java
@@ -1,0 +1,23 @@
+package kr.co.api.goal.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import kr.co.domain.goal.Goal;
+
+public record GoalWithSubGoalTodoDto(
+        UUID id,
+        String title,
+        LocalDate dueDate,
+        List<SubGoalWithTodosDto> subGoals
+) {
+
+    public static GoalWithSubGoalTodoDto of(Goal goal, List<SubGoalWithTodosDto> subGoals) {
+        return new GoalWithSubGoalTodoDto(
+                goal.getId(),
+                goal.getTitle(),
+                goal.getDueDateValue(),
+                subGoals
+        );
+    }
+}

--- a/motimo-api/src/main/java/kr/co/api/goal/dto/SubGoalWithTodosDto.java
+++ b/motimo-api/src/main/java/kr/co/api/goal/dto/SubGoalWithTodosDto.java
@@ -1,0 +1,14 @@
+package kr.co.api.goal.dto;
+
+import java.util.List;
+import java.util.UUID;
+import kr.co.domain.todo.dto.TodoItemDto;
+
+public record SubGoalWithTodosDto(
+        UUID id,
+        String title,
+        boolean isCompleted,
+        List<TodoItemDto> todos
+) {
+
+}

--- a/motimo-api/src/main/java/kr/co/api/goal/rqrs/GoalWithSubGoalTodoRs.java
+++ b/motimo-api/src/main/java/kr/co/api/goal/rqrs/GoalWithSubGoalTodoRs.java
@@ -1,0 +1,28 @@
+package kr.co.api.goal.rqrs;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import kr.co.api.goal.dto.GoalWithSubGoalTodoDto;
+
+public record GoalWithSubGoalTodoRs(
+        @Schema(description = "목표 Id", example = "0197157f-aea4-77bb-8581-3213eb5bd2aq", requiredMode = Schema.RequiredMode.REQUIRED)
+        UUID id,
+        @Schema(description = "목표 이름", example = "자격증 따기", requiredMode = Schema.RequiredMode.REQUIRED)
+        String title,
+        @Schema(description = "목표 완료 날짜", type = "date", requiredMode = Schema.RequiredMode.REQUIRED)
+        LocalDate dueDate,
+        @Schema(description = "투두를 포함한 세부 목표 목록")
+        List<SubGoalWithTodosRs> subGoals
+) {
+
+    public static GoalWithSubGoalTodoRs from(GoalWithSubGoalTodoDto dto) {
+        return new GoalWithSubGoalTodoRs(
+                dto.id(),
+                dto.title(),
+                dto.dueDate(),
+                dto.subGoals().stream().map(SubGoalWithTodosRs::from).toList()
+        );
+    }
+}

--- a/motimo-api/src/main/java/kr/co/api/goal/rqrs/SubGoalWithTodosRs.java
+++ b/motimo-api/src/main/java/kr/co/api/goal/rqrs/SubGoalWithTodosRs.java
@@ -1,0 +1,31 @@
+package kr.co.api.goal.rqrs;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import java.util.UUID;
+import kr.co.api.goal.dto.SubGoalWithTodosDto;
+import kr.co.api.todo.rqrs.TodoRs;
+
+public record SubGoalWithTodosRs(
+        @Schema(description = "세부 목표 Id", example = "0197157f-aea4-77bb-8581-3213eb5bd2ae", requiredMode = Schema.RequiredMode.REQUIRED)
+        UUID id,
+
+        @Schema(description = "세부 목표 이름", example = "책 한 권 끝내기", requiredMode = Schema.RequiredMode.REQUIRED)
+        String title,
+
+        @Schema(description = "세부 목표 완료 여부", example = "false", requiredMode = Schema.RequiredMode.REQUIRED)
+        boolean isCompleted,
+
+        @Schema(description = "세부 목표에 해당하는 투두 목록")
+        List<TodoRs> todos
+) {
+
+    public static SubGoalWithTodosRs from(SubGoalWithTodosDto dto) {
+        return new SubGoalWithTodosRs(
+                dto.id(),
+                dto.title(),
+                dto.isCompleted(),
+                dto.todos().stream().map(TodoRs::from).toList()
+        );
+    }
+}

--- a/motimo-api/src/main/java/kr/co/api/todo/service/TodoQueryService.java
+++ b/motimo-api/src/main/java/kr/co/api/todo/service/TodoQueryService.java
@@ -29,6 +29,15 @@ public class TodoQueryService {
     private final TodoResultRepository todoResultRepository;
     private final StorageService storageService;
 
+    public List<TodoItemDto> getIncompleteOrTodayTodosBySubGoalId(UUID subGoalId) {
+        LocalDate today = LocalDate.now();
+        return todoRepository.findAllIncompleteOrDateTodoBySubGoalId(subGoalId, today)
+                .stream()
+                .map(this::enrichTodoItemWithUrl)
+                .sorted(todoPriorityComparator())
+                .toList();
+    }
+
     public CustomSlice<TodoItemDto> getIncompleteOrTodayTodosBySubGoalIdWithSlice(UUID subGoalId,
             int offset, int size) {
         LocalDate today = LocalDate.now();

--- a/motimo-domain/src/main/java/kr/co/domain/todo/repository/TodoRepository.java
+++ b/motimo-domain/src/main/java/kr/co/domain/todo/repository/TodoRepository.java
@@ -21,6 +21,8 @@ public interface TodoRepository {
     List<TodoItemDto> findAllByUserId(UUID userId);
 
     List<TodoItemDto> findAllBySubGoalId(UUID subGoalId);
+    
+    List<TodoItemDto> findAllIncompleteOrDateTodoBySubGoalId(UUID subGoalId, LocalDate today);
 
     CustomSlice<TodoItemDto> findAllBySubGoalIdWithSlice(UUID subGoalId, int offset, int size);
 

--- a/motimo-infra-rdb/src/main/java/kr/co/infra/rdb/todo/repository/TodoRepositoryImpl.java
+++ b/motimo-infra-rdb/src/main/java/kr/co/infra/rdb/todo/repository/TodoRepositoryImpl.java
@@ -95,6 +95,24 @@ public class TodoRepositoryImpl implements TodoRepository {
     }
 
     @Override
+    public List<TodoItemDto> findAllIncompleteOrDateTodoBySubGoalId(UUID subGoalId,
+            LocalDate today) {
+        QTodoEntity todoEntity = QTodoEntity.todoEntity;
+        QTodoResultEntity todoResultEntity = QTodoResultEntity.todoResultEntity;
+
+        return todoItemJPAQuery(todoEntity, todoResultEntity)
+                .where(
+                        todoEntity.subGoalId.eq(subGoalId)
+                                .and(anyOf(
+                                        todoEntity.status.ne(TodoStatus.COMPLETE),
+                                        todoEntity.date.eq(today)
+                                ))
+                )
+                .fetch();
+    }
+
+
+    @Override
     public boolean existsById(UUID id) {
         return todoJpaRepository.existsById(id);
     }


### PR DESCRIPTION
## 📌 관련 이슈

<br>

## ✨ 작업 개요

기존에 있던 /goals/{goalId}/sub-goals/all api를 다시 구현했습니다.

<br>

## ✅ 작업 상세 내용

<br>

## 📸 스크린샷 (선택)

<br>

## 💬 기타 참고 사항

<br>

## 🔍 고민 지점


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public API endpoint to retrieve a goal along with its sub-goals and today's incomplete todos.
  * Extended API documentation to describe the new endpoint and its response structure.

* **Bug Fixes**
  * Corrected a path variable in the goals API to ensure accurate endpoint matching.

* **Chores**
  * Made certain goal and sub-goal endpoints accessible without authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->