### PR TITLE
refac: todo result 제출 후 메시지 조회시 제대로된 filurl을 반환하도록 수정

### DIFF
--- a/motimo-api/src/main/java/kr/co/api/group/service/message/MessageContentLoader.java
+++ b/motimo-api/src/main/java/kr/co/api/group/service/message/MessageContentLoader.java
@@ -103,7 +103,7 @@ public class MessageContentLoader {
         }
 
         return todoResultRepository.findAllByIdsIn(todoResultIds).stream()
-                .peek(todoResult -> {
+                .map(todoResult -> {
                     TodoResultFile file = todoResult.getFile();
                     if (file != null && StringUtils.hasText(file.getFilePath())) {
                         String fileUrl = storageService.getFileUrl(file.getFilePath());
@@ -115,6 +115,7 @@ public class MessageContentLoader {
                         );
                         todoResult.updateFile(enrichedFile);
                     }
+                    return todoResult;
                 })
                 .collect(Collectors.toMap(TodoResult::getId, todoResult -> todoResult));
     }

--- a/motimo-api/src/main/java/kr/co/api/group/service/message/MessageContentLoader.java
+++ b/motimo-api/src/main/java/kr/co/api/group/service/message/MessageContentLoader.java
@@ -16,14 +16,17 @@ import kr.co.domain.group.message.MessageReferenceType;
 import kr.co.domain.group.message.strategy.MessageContentData;
 import kr.co.domain.todo.Todo;
 import kr.co.domain.todo.TodoResult;
+import kr.co.domain.todo.TodoResultFile;
 import kr.co.domain.todo.repository.TodoRepository;
 import kr.co.domain.todo.repository.TodoResultRepository;
 import kr.co.domain.user.model.User;
 import kr.co.domain.user.repository.UserRepository;
+import kr.co.infra.storage.service.StorageService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataAccessException;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 @Slf4j
 @Component
@@ -34,6 +37,7 @@ public class MessageContentLoader {
     private final TodoResultRepository todoResultRepository;
     private final UserRepository userRepository;
     private final GoalRepository goalRepository;
+    private final StorageService storageService;
 
     public MessageContentData loadMessageContentData(List<GroupMessage> messages) {
 
@@ -99,6 +103,19 @@ public class MessageContentLoader {
         }
 
         return todoResultRepository.findAllByIdsIn(todoResultIds).stream()
+                .peek(todoResult -> {
+                    TodoResultFile file = todoResult.getFile();
+                    if (file != null && StringUtils.hasText(file.getFilePath())) {
+                        String fileUrl = storageService.getFileUrl(file.getFilePath());
+
+                        TodoResultFile enrichedFile = TodoResultFile.of(
+                                fileUrl,
+                                file.getFileName(),
+                                file.getMimeType()
+                        );
+                        todoResult.updateFile(enrichedFile);
+                    }
+                })
                 .collect(Collectors.toMap(TodoResult::getId, todoResult -> todoResult));
     }
 

--- a/motimo-domain/src/main/java/kr/co/domain/todo/TodoResult.java
+++ b/motimo-domain/src/main/java/kr/co/domain/todo/TodoResult.java
@@ -48,4 +48,8 @@ public class TodoResult {
         this.content = content;
         this.file = TodoResultFile.of(filePath, fileName, mimeType);
     }
+
+    public void updateFile(TodoResultFile file) {
+        this.file = file;
+    }
 }


### PR DESCRIPTION
## 📌 관련 이슈

<br>

## ✨ 작업 개요
<img width="671" height="94" alt="image" src="https://github.com/user-attachments/assets/3b1870c4-e1a3-47e3-b905-37a15b8d9618" />

<br>

## ✅ 작업 상세 내용

투두결과 메시지 조회시 실제 url을 가져오도록 수정했어요

<br>

## 📸 스크린샷 (선택)

<br>

## 💬 기타 참고 사항

<br>

## 🔍 고민 지점


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File URLs are now included in TodoResult items, allowing direct access to associated files.
* **Enhancements**
  * Improved handling of file information within TodoResult details for a more seamless user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->