### PR TITLE
feat: goalID를 통해 모든 세부목표 + 투두 리스트 조회

### DIFF
--- a/motimo-api/src/main/java/kr/co/api/goal/GoalReadController.java
+++ b/motimo-api/src/main/java/kr/co/api/goal/GoalReadController.java
@@ -50,10 +50,18 @@ public class GoalReadController implements GoalReadControllerSwagger {
     }
 
     @GetMapping("/{goalId}/sub-goals/all")
-    public GoalWithSubGoalTodoRs getGoalWithSubGoalAndTodos(@PathVariable UUID goalId) {
+    public GoalWithSubGoalTodoRs getGoalWithSubGoalAndIncompleteOrTodayTodos(
+            @PathVariable UUID goalId) {
         return GoalWithSubGoalTodoRs.from(
                 goalQueryService.getGoalWithIncompleteSubGoalTodayTodos(goalId));
     }
+
+    @GetMapping("/{goalId}/sub-goals/todos/all")
+    public GoalWithSubGoalTodoRs getGoalWithSubGoalAndTodos(@PathVariable UUID goalId) {
+        return GoalWithSubGoalTodoRs.from(
+                goalQueryService.getGoalWithSubGoalTodos(goalId));
+    }
+
 
     @GetMapping("/not-joined-group")
     public List<GoalNotInGroupRs> getGoalNotJoinGroup(@AuthUser UUID userId) {

--- a/motimo-api/src/main/java/kr/co/api/goal/docs/GoalReadControllerSwagger.java
+++ b/motimo-api/src/main/java/kr/co/api/goal/docs/GoalReadControllerSwagger.java
@@ -42,6 +42,20 @@ public interface GoalReadControllerSwagger {
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", content = @Content),
             @ApiResponse(responseCode = "404", description = "해당 목표를 찾을 수 없음", content = @Content)
     })
+    GoalWithSubGoalTodoRs getGoalWithSubGoalAndIncompleteOrTodayTodos(
+            @Parameter(description = "목표 ID", required = true, example = "123e4567-e89b-12d3-a456-426614174000")
+            @PathVariable UUID goalId
+    );
+
+    @Operation(
+            summary = "목표 + 세부목표 + 투두 조회 API",
+            description = "목표 ID에 해당하는 목표 정보와 모든 세부 목표 및 투두 목록을 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "목표, 세부목표, 투두 목록 반환", content = @Content(schema = @Schema(implementation = GoalWithSubGoalTodoRs.class))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", content = @Content),
+            @ApiResponse(responseCode = "404", description = "해당 목표를 찾을 수 없음", content = @Content)
+    })
     GoalWithSubGoalTodoRs getGoalWithSubGoalAndTodos(
             @Parameter(description = "목표 ID", required = true, example = "123e4567-e89b-12d3-a456-426614174000")
             @PathVariable UUID goalId

--- a/motimo-api/src/main/java/kr/co/api/goal/service/GoalQueryService.java
+++ b/motimo-api/src/main/java/kr/co/api/goal/service/GoalQueryService.java
@@ -107,6 +107,12 @@ public class GoalQueryService {
         return GoalWithSubGoalTodoDto.of(goal, subGoals);
     }
 
+    public GoalWithSubGoalTodoDto getGoalWithSubGoalTodos(UUID goalId) {
+        Goal goal = goalRepository.findById(goalId);
+        List<SubGoalWithTodosDto> subGoals = getTodoBySubGoalList(goal.getSubGoals());
+        return GoalWithSubGoalTodoDto.of(goal, subGoals);
+    }
+
     private List<SubGoalWithTodosDto> getTodoByIncompleteSubGoalList(List<SubGoal> subGoals) {
         return subGoals.stream()
                 .sorted(Comparator.comparing(SubGoal::getOrder))
@@ -114,6 +120,18 @@ public class GoalQueryService {
                     List<TodoItemDto> todos = todoQueryService.getIncompleteOrTodayTodosBySubGoalId(
                             subGoal.getId());
 
+                    return new SubGoalWithTodosDto(subGoal.getId(), subGoal.getTitle(),
+                            subGoal.isCompleted(), todos);
+                })
+                .toList();
+    }
+
+    private List<SubGoalWithTodosDto> getTodoBySubGoalList(List<SubGoal> subGoals) {
+        return subGoals.stream()
+                .sorted(Comparator.comparing(SubGoal::getOrder))
+                .map(subGoal -> {
+                    List<TodoItemDto> todos = todoQueryService.getTodosBySubGoalId(
+                            subGoal.getId());
                     return new SubGoalWithTodosDto(subGoal.getId(), subGoal.getTitle(),
                             subGoal.isCompleted(), todos);
                 })

--- a/motimo-api/src/main/java/kr/co/api/todo/service/TodoQueryService.java
+++ b/motimo-api/src/main/java/kr/co/api/todo/service/TodoQueryService.java
@@ -74,6 +74,13 @@ public class TodoQueryService {
                 .toList();
     }
 
+    public List<TodoItemDto> getTodosBySubGoalId(UUID subGoalId) {
+        return todoRepository.findAllBySubGoalId(subGoalId).stream()
+                .sorted(todoPriorityComparator())
+                .map(this::enrichTodoItemWithUrl)
+                .toList();
+    }
+
     public List<Todo> getTodosByGoalId(UUID goalId) {
         return todoRepository.findAllByGoalId(goalId);
     }


### PR DESCRIPTION
## 📌 관련 이슈

<br>

## ✨ 작업 개요
<img width="569" height="77" alt="image" src="https://github.com/user-attachments/assets/a0ffd00a-ebad-4444-b5e8-541b67ad8860" />

<br>

## ✅ 작업 상세 내용
목표 아이디로 목표 정보와 세부목표 리스트 + 투두 리스트를 한번에 조회하도록 하는 API 만들었어요.

<br>

## 📸 스크린샷 (선택)

<br>

## 💬 기타 참고 사항

<br>

## 🔍 고민 지점
