### PR TITLE
[feat] 유저 탈퇴 

### DIFF
--- a/motimo-api/src/main/java/kr/co/api/goal/service/GoalQueryService.java
+++ b/motimo-api/src/main/java/kr/co/api/goal/service/GoalQueryService.java
@@ -101,6 +101,10 @@ public class GoalQueryService {
         return goalRepository.findBySubGoalId(subGoalId);
     }
 
+    public List<Goal> getGoalsByUserId(UUID userId) {
+        return goalRepository.findAllByUserId(userId);
+    }
+
     public GoalWithSubGoalTodoDto getGoalWithIncompleteSubGoalTodayTodos(UUID goalId) {
         Goal goal = goalRepository.findById(goalId);
         List<SubGoalWithTodosDto> subGoals = getTodoByIncompleteSubGoalList(goal.getSubGoals());

--- a/motimo-api/src/main/java/kr/co/api/group/service/GroupCommandService.java
+++ b/motimo-api/src/main/java/kr/co/api/group/service/GroupCommandService.java
@@ -83,4 +83,12 @@ public class GroupCommandService {
         ));
     }
 
+    public void removeUserFromGroup(UUID userId, UUID groupId) {
+        Group group = groupRepository.findById(groupId);
+        GroupMember member = group.getMember(userId);
+
+        groupRepository.left(groupId, member);
+        goalRepository.disconnectGroupByGoalId(member.getGoalId());
+    }
+
 }

--- a/motimo-api/src/main/java/kr/co/api/group/service/GroupMessageCommandService.java
+++ b/motimo-api/src/main/java/kr/co/api/group/service/GroupMessageCommandService.java
@@ -30,4 +30,8 @@ public class GroupMessageCommandService {
         return groupMessageRepository.findById(messageId)
                 .orElseThrow(MessageNotFoundException::new);
     }
+
+    public void deleteAllByUserId(UUID userId) {
+        groupMessageRepository.deleteAllByUserId(userId);
+    }
 }

--- a/motimo-api/src/main/java/kr/co/api/user/UserController.java
+++ b/motimo-api/src/main/java/kr/co/api/user/UserController.java
@@ -10,6 +10,7 @@ import kr.co.api.user.rqrs.UserUpdateRq;
 import kr.co.api.user.service.UserCommandService;
 import kr.co.api.user.service.UserQueryService;
 import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -58,5 +59,10 @@ public class UserController implements UserControllerSwagger {
         UUID id = userCommandService.updateProfile(userId,
                 request.userName(), request.bio(), request.interests(), image);
         return new UserIdRs(id);
+    }
+
+    @DeleteMapping()
+    public void deleteUser(@AuthUser UUID userId) {
+        userCommandService.deleteUserCascadeById(userId);
     }
 }

--- a/motimo-api/src/main/java/kr/co/api/user/docs/UserControllerSwagger.java
+++ b/motimo-api/src/main/java/kr/co/api/user/docs/UserControllerSwagger.java
@@ -59,4 +59,11 @@ public interface UserControllerSwagger {
             @RequestPart @Schema(implementation = UserUpdateRq.class) UserUpdateRq request,
             @Parameter(description = "프로필 이미지 파일", content = @Content(mediaType = "multipart/form-data"))
             @RequestPart(name = "file", required = false) MultipartFile image);
+
+    @Operation(summary = "유저 탈퇴")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "탈퇴 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", content = @Content)
+    })
+    void deleteUser(UUID userId);
 }

--- a/motimo-domain/src/main/java/kr/co/domain/group/message/repository/GroupMessageRepository.java
+++ b/motimo-domain/src/main/java/kr/co/domain/group/message/repository/GroupMessageRepository.java
@@ -24,4 +24,6 @@ public interface GroupMessageRepository {
     Optional<GroupMessage> findLastGroupMessageByGroupId(UUID groupId);
 
     Optional<GroupMessage> findById(UUID id);
+
+    void deleteAllByUserId(UUID userId);
 }

--- a/motimo-domain/src/main/java/kr/co/domain/user/repository/UserRepository.java
+++ b/motimo-domain/src/main/java/kr/co/domain/user/repository/UserRepository.java
@@ -13,7 +13,7 @@ public interface UserRepository {
     User findByEmail(String email);
 
     User findByEmailAndProviderType(String email, ProviderType providerType);
-    
+
     User create(User user);
 
     User update(User user);
@@ -21,4 +21,6 @@ public interface UserRepository {
     boolean existsByEmailAndProviderType(String email, ProviderType providerType);
 
     List<User> findAllByIdsIn(Set<UUID> userIds);
+
+    void deleteById(UUID userId);
 }

--- a/motimo-infra-rdb/src/main/java/kr/co/infra/rdb/group/message/repository/GroupMessageJpaRepository.java
+++ b/motimo-infra-rdb/src/main/java/kr/co/infra/rdb/group/message/repository/GroupMessageJpaRepository.java
@@ -10,4 +10,6 @@ public interface GroupMessageJpaRepository extends JpaRepository<GroupMessageEnt
     void deleteAllByMessageReferenceReferenceId(UUID referenceId);
 
     Optional<GroupMessageEntity> findTopByGroupIdOrderBySendAtDesc(UUID groupId);
+
+    void deleteAllByUserId(UUID userId);
 }

--- a/motimo-infra-rdb/src/main/java/kr/co/infra/rdb/group/message/repository/GroupMessageRepositoryImpl.java
+++ b/motimo-infra-rdb/src/main/java/kr/co/infra/rdb/group/message/repository/GroupMessageRepositoryImpl.java
@@ -137,6 +137,11 @@ public class GroupMessageRepositoryImpl implements GroupMessageRepository {
         return entity.map(GroupMessageMapper::toDomain);
     }
 
+    @Override
+    public void deleteAllByUserId(UUID userId) {
+        groupMessageJpaRepository.deleteAllByUserId(userId);
+    }
+
     private List<GroupMessage> processMessagesWithReactions(List<GroupMessageEntity> messages) {
         if (messages.isEmpty()) {
             return List.of();

--- a/motimo-infra-rdb/src/main/java/kr/co/infra/rdb/user/entity/UserEntity.java
+++ b/motimo-infra-rdb/src/main/java/kr/co/infra/rdb/user/entity/UserEntity.java
@@ -44,7 +44,7 @@ public class UserEntity {
     @Column(name = "id")
     private UUID id;
 
-    @Column(name = "email", unique = true)
+    @Column(name = "email")
     private String email;
 
     @Column(name = "nickname")

--- a/motimo-infra-rdb/src/main/java/kr/co/infra/rdb/user/repository/UserRepositoryImpl.java
+++ b/motimo-infra-rdb/src/main/java/kr/co/infra/rdb/user/repository/UserRepositoryImpl.java
@@ -69,4 +69,9 @@ public class UserRepositoryImpl implements UserRepository {
                 .map(UserMapper::toDomain)
                 .toList();
     }
+
+    @Override
+    public void deleteById(UUID userId) {
+        userJpaRepository.deleteById(userId);
+    }
 }

--- a/motimo-infra-rdb/src/main/resources/db/migration/V18__update_user_schema.sql
+++ b/motimo-infra-rdb/src/main/resources/db/migration/V18__update_user_schema.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users
+DROP CONSTRAINT IF EXISTS users_email_key;


### PR DESCRIPTION
## 📌 관련 이슈

<br>

## ✨ 작업 개요
<img width="322" height="112" alt="image" src="https://github.com/user-attachments/assets/ebff69b5-728d-4994-9c2f-5fd815eedd43" />


<br>

## ✅ 작업 상세 내용

유저 탈퇴시, 참여중인 그룹, 그룹 메시지, 목표-세부목표-투두-투두결과 모두 삭제

고민되는건 그룹 메시지는 남기고 싶었는데 그렇게 되면 현재 그룹 메시지에 저희가 저장하고 있는  user Id를 통해서 유저를 조회해 유저 이름을 반환해주고 있는데 해당 로직을 모두 수정해야함.

> 유저 탈퇴시 그룹에서 빼고 그룹 메시지도 모두 삭제하도록 함 (일단..) 

<br>

## 📸 스크린샷 (선택)

<br>

## 💬 기타 참고 사항

<br>

## 🔍 고민 지점
